### PR TITLE
Add NextAuth credential-based authentication

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Secret used to sign NextAuth.js tokens
+AUTH_SECRET=your-secret-value

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!.env.example
 
 # vercel
 .vercel

--- a/app/account/login/actions.ts
+++ b/app/account/login/actions.ts
@@ -1,0 +1,42 @@
+'use server';
+
+import { signIn } from '@/auth';
+import { redirect } from 'next/navigation';
+import { AuthError } from 'next-auth';
+
+type LoginFormState = {
+  error?: string | null;
+};
+
+export async function authenticate(
+  prevState: LoginFormState,
+  formData: FormData,
+): Promise<LoginFormState> {
+  const email = formData.get('email');
+  const password = formData.get('password');
+
+  if (typeof email !== 'string' || typeof password !== 'string') {
+    return { error: 'Please provide your email and password.' };
+  }
+
+  try {
+    await signIn('credentials', {
+      redirect: false,
+      email,
+      password,
+    });
+  } catch (error) {
+    if (error instanceof AuthError) {
+      switch (error.type) {
+        case 'CredentialsSignin':
+          return { error: 'Invalid email or password. Please try again.' };
+        default:
+          return { error: 'Something went wrong. Please try again later.' };
+      }
+    }
+
+    throw error;
+  }
+
+  redirect('/dashboard');
+}

--- a/app/account/login/login-form.tsx
+++ b/app/account/login/login-form.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { useState } from 'react';
+import { useFormState, useFormStatus } from 'react-dom';
+import Link from 'next/link';
+import { authenticate } from './actions';
+
+type FormState = {
+  error: string | null;
+};
+
+const initialState: FormState = {
+  error: null,
+};
+
+function SubmitButton() {
+  const { pending } = useFormStatus();
+
+  return (
+    <button
+      type='submit'
+      className='w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition disabled:opacity-70 disabled:cursor-not-allowed'
+      disabled={pending}
+    >
+      {pending ? 'Signing in…' : 'Login'}
+    </button>
+  );
+}
+
+export default function LoginForm() {
+  const [state, formAction] = useFormState(authenticate, initialState);
+  const [formData, setFormData] = useState({
+    email: '',
+    password: '',
+  });
+
+  const getBorderClass = (field: keyof typeof formData) => {
+    const value = formData[field].trim();
+
+    if (field === 'email') {
+      const isValidEmail = /[^\s@]+@[^\s@]+\.[^\s@]+/.test(value);
+      return value.length === 0 ? 'border-gray-300' : isValidEmail ? 'border-green-500' : 'border-red-500';
+    }
+
+    if (field === 'password') {
+      return value.length === 0 ? 'border-gray-300' : value.length >= 6 ? 'border-green-500' : 'border-red-500';
+    }
+
+    return value ? 'border-green-500' : 'border-gray-300';
+  };
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormData((prev) => ({ ...prev, [name]: value }));
+  };
+
+  return (
+    <form action={formAction} className='space-y-4'>
+      <input
+        type='email'
+        name='email'
+        placeholder='Email Address'
+        value={formData.email}
+        onChange={handleChange}
+        className={`w-full px-4 py-2 rounded-md border ${getBorderClass('email')} text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-400`}
+        required
+        autoComplete='email'
+      />
+
+      <input
+        type='password'
+        name='password'
+        placeholder='Password'
+        value={formData.password}
+        onChange={handleChange}
+        className={`w-full px-4 py-2 rounded-md border ${getBorderClass('password')} text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-400`}
+        required
+        autoComplete='current-password'
+      />
+
+      <SubmitButton />
+
+      {state.error && (
+        <p className='mt-2 text-sm text-red-600 text-center'>
+          {state.error}
+        </p>
+      )}
+
+      <p className='text-sm text-gray-600 text-center'>
+        Don’t have an account?{' '}
+        <Link href='/account' className='text-blue-600 hover:underline'>
+          Register
+        </Link>
+      </p>
+    </form>
+  );
+}

--- a/app/account/login/page.tsx
+++ b/app/account/login/page.tsx
@@ -1,105 +1,11 @@
-'use client';
-
-import { useState } from 'react';
+import LoginForm from './login-form';
 
 export default function LoginPage() {
-  const [formData, setFormData] = useState({
-    email: '',
-    password: '',
-  });
-
-    const getBorderClass = (field: keyof typeof formData) => {
-        const value = formData[field].trim();
-        // Email field
-        if (field === 'email') {
-            const isValidEmail = /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-            return isValidEmail ? 'border-green-500' : 'border-red-500';
-        }
-        // password field
-        if (field === 'password') return 'border-gray-300';
-        return value ? 'border-green-500' : 'border-red-500';
-    };
-
-  const [errors, setErrors] = useState<string[]>([]);
-  const [success, setSuccess] = useState<string | null>(null);
-
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const { name, value } = e.target;
-    setFormData(prev => ({ ...prev, [name]: value }));
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
-    setErrors([]);
-    setSuccess(null);
-
-    const res = await fetch('/api/login', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(formData),
-    });
-
-    const data = await res.json();
-
-    if (!res.ok) {
-      setErrors(data.errors || ['Invalid email or password']);
-    } else {
-      setSuccess(data.message);
-      setFormData({ email: '', password: '' });
-    }
-  };
-
   return (
-    <main className="min-h-screen flex items-center justify-center bg-gray-600 px-4 py-12">
-      <div className="bg-white shadow-xl rounded-lg p-8 w-full max-w-md">
-        <h1 className="text-2xl font-bold mb-6 text-center text-gray-800">Login</h1>
-
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <input
-            type="email"
-            name="email"
-            placeholder="Email Address"
-            value={formData.email}
-            onChange={handleChange}
-            className={`w-full px-4 py-2 rounded-md border ${getBorderClass(
-                    'email'
-                )} text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-400`}
-                required
-            />
-          <input
-            type="password"
-            name="password"
-            placeholder="Password"
-            value={formData.password}
-            onChange={handleChange}
-            className={`w-full px-4 py-2 border-gray-400 rounded-md border ${getBorderClass(
-                    'password'
-                )} text-gray-800 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-400`}
-                required
-            />
-          <button
-            type="submit"
-            className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 transition"
-          >
-            Login
-          </button>
-        </form>
-
-        {errors.length > 0 && (
-          <div className="mt-4 text-red-600 text-sm space-y-1">
-            {errors.map((err, i) => (
-              <p key={i}>• {err}</p>
-            ))}
-          </div>
-        )}
-
-        {success && (
-          <p className="mt-4 text-green-600 text-sm text-center">{success}</p>
-        )}
-
-        <p className="text-sm text-gray-600 text-center mt-6">
-          Don’t have an account? <a href="/account" className="text-blue-600 hover:underline">Register</a>
-        </p>
+    <main className='min-h-screen flex items-center justify-center bg-gray-600 px-4 py-12'>
+      <div className='bg-white shadow-xl rounded-lg p-8 w-full max-w-md'>
+        <h1 className='text-2xl font-bold mb-6 text-center text-gray-800'>Login</h1>
+        <LoginForm />
       </div>
     </main>
   );

--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/app/components/Header.tsx
+++ b/app/components/Header.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link'
 import { useState, useEffect } from 'react'
 import { usePathname } from 'next/navigation'
+import { signOut, useSession } from 'next-auth/react'
 import {
 	Facebook,
 	Instagram,
@@ -19,10 +20,11 @@ export default function Header({
 }: {
 	forceDarkMode?: boolean
 }) {
-	const [openMenu, setOpenMenu] = useState<string | null>(null)
-	const [scrolled, setScrolled] = useState(false)
-	const [mobileOpen, setMobileOpen] = useState(false)
-	const pathname = usePathname()
+        const [openMenu, setOpenMenu] = useState<string | null>(null)
+        const [scrolled, setScrolled] = useState(false)
+        const [mobileOpen, setMobileOpen] = useState(false)
+        const pathname = usePathname()
+        const { data: session, status } = useSession()
 
 	// Check if we're on a seller page
 	const isSellerPage = pathname?.startsWith('/seller/')
@@ -163,11 +165,28 @@ export default function Header({
 						</select>
 
 						{/* Account */}
-						<Link
-							href='/account'
-							className={`${linkBase} ${linkHover}`}>
-							<User className='inline h-5 w-5' />
-						</Link>
+                                                {status === 'authenticated' ? (
+                                                        <button
+                                                                type='button'
+                                                                onClick={() => signOut({ redirectTo: '/' })}
+                                                                className={`${linkBase} ${linkHover} flex items-center gap-2`}
+                                                        >
+                                                                <User className='h-5 w-5' />
+                                                                {session?.user?.name && (
+                                                                        <span className='hidden lg:inline'>
+                                                                                {session.user.name}
+                                                                        </span>
+                                                                )}
+                                                                <span className='hidden md:inline'>Sign out</span>
+                                                        </button>
+                                                ) : (
+                                                        <Link
+                                                                href='/account/login'
+                                                                className={`${linkBase} ${linkHover} flex items-center gap-2`}>
+                                                                <User className='h-5 w-5' />
+                                                                <span className='hidden md:inline'>Sign in</span>
+                                                        </Link>
+                                                )}
 
 						{/* Cart */}
 						<Link
@@ -235,8 +254,26 @@ export default function Header({
 								</div>
 							</details>
 
-							<Link href='/faqs'>FAQs</Link>
-							<Link href='/account'>Account</Link>
+                                                        <Link href='/faqs'>FAQs</Link>
+                                                        {status === 'authenticated' ? (
+                                                                <button
+                                                                        type='button'
+                                                                        onClick={() => {
+                                                                                signOut({ redirectTo: '/' })
+                                                                                setMobileOpen(false)
+                                                                        }}
+                                                                        className='text-left'
+                                                                >
+                                                                        Sign out
+                                                                </button>
+                                                        ) : (
+                                                                <Link
+                                                                        href='/account/login'
+                                                                        onClick={() => setMobileOpen(false)}
+                                                                >
+                                                                        Sign in
+                                                                </Link>
+                                                        )}
 							<Link href='/cart'>Cart (0)</Link>
 						</nav>
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -3,6 +3,7 @@ import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Header from "@/app/components/Header";
 import Footer from "@/app/components/Footer";
+import Providers from "./providers";
 
 
 const geistSans = Geist({
@@ -30,9 +31,11 @@ export default function RootLayout({
       <body
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
-        <Header />
-        {children}
-        <Footer />
+        <Providers>
+          <Header />
+          {children}
+          <Footer />
+        </Providers>
       </body>
     </html>
   );

--- a/app/lib/users.ts
+++ b/app/lib/users.ts
@@ -1,0 +1,19 @@
+export type User = {
+  id: string;
+  name: string;
+  email: string;
+  password: string;
+};
+
+const users: User[] = [
+  {
+    id: "1",
+    name: "Luna Artisan",
+    email: "user@nextmail.com",
+    password: "$2b$10$AICXH8ivr71I8ujteBPn3ev4H6n9g5oxdfszcIXxux9Jv1XDnXl5G",
+  },
+];
+
+export async function getUserByEmail(email: string) {
+  return users.find((user) => user.email.toLowerCase() === email.toLowerCase()) ?? null;
+}

--- a/app/providers.tsx
+++ b/app/providers.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import { SessionProvider } from "next-auth/react";
+
+export default function Providers({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return <SessionProvider>{children}</SessionProvider>;
+}

--- a/auth.config.ts
+++ b/auth.config.ts
@@ -1,0 +1,72 @@
+import type { NextAuthConfig } from "next-auth";
+import Credentials from "next-auth/providers/credentials";
+import bcrypt from "bcrypt";
+import { getUserByEmail } from "@/app/lib/users";
+
+function validateCredentials(credentials: Record<string, unknown> | undefined) {
+  if (!credentials) {
+    return null;
+  }
+
+  const email = typeof credentials.email === "string" ? credentials.email.trim() : "";
+  const password = typeof credentials.password === "string" ? credentials.password : "";
+
+  if (!email || !email.includes("@")) {
+    return null;
+  }
+
+  if (password.length < 6) {
+    return null;
+  }
+
+  return { email, password };
+}
+
+export default {
+  providers: [
+    Credentials({
+      async authorize(credentials) {
+        const parsedCredentials = validateCredentials(credentials);
+
+        if (!parsedCredentials) {
+          return null;
+        }
+
+        const { email, password } = parsedCredentials;
+        const user = await getUserByEmail(email);
+
+        if (!user) {
+          return null;
+        }
+
+        const passwordMatches = await bcrypt.compare(password, user.password);
+
+        if (!passwordMatches) {
+          return null;
+        }
+
+        return {
+          id: user.id,
+          name: user.name,
+          email: user.email,
+        };
+      },
+    }),
+  ],
+  pages: {
+    signIn: "/account/login",
+  },
+  session: {
+    strategy: "jwt",
+  },
+  callbacks: {
+    async session({ session, token }) {
+      if (session.user && token.sub) {
+        session.user.id = token.sub;
+      }
+
+      return session;
+    },
+  },
+  secret: process.env.AUTH_SECRET,
+} satisfies NextAuthConfig;

--- a/auth.ts
+++ b/auth.ts
@@ -1,0 +1,4 @@
+import NextAuth from "next-auth";
+import authConfig from "./auth.config";
+
+export const { auth, handlers, signIn, signOut } = NextAuth(authConfig);

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,0 +1,5 @@
+export { auth as middleware } from "./auth";
+
+export const config = {
+  matcher: ["/dashboard/:path*", "/seller/:path*"],
+};

--- a/next-auth.d.ts
+++ b/next-auth.d.ts
@@ -1,0 +1,13 @@
+import NextAuth, { DefaultSession } from "next-auth";
+
+declare module "next-auth" {
+  interface Session {
+    user: DefaultSession["user"] & {
+      id: string;
+    };
+  }
+
+  interface User {
+    id: string;
+  }
+}

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "bcrypt": "^6.0.0",
     "lucide-react": "^0.544.0",
     "next": "15.5.3",
+    "next-auth": "^5.0.0-beta.25",
     "postgres": "^3.4.7",
     "react": "19.1.0",
     "react-dom": "19.1.0",


### PR DESCRIPTION
## Summary
- configure NextAuth credential provider with middleware and API route for session management
- wire the app layout and header to the session provider so authenticated users can sign out across desktop and mobile menus
- replace the login page with a server action powered form that signs in through NextAuth and add a sample credential user and env template

## Testing
- `pnpm run build` *(fails: remote font downloads and missing next-auth package due to restricted network)*

------
https://chatgpt.com/codex/tasks/task_e_68e4f50d96bc832183de1aff92e28814